### PR TITLE
feat: add hyperevm

### DIFF
--- a/packages/common/src/constants/networks.ts
+++ b/packages/common/src/constants/networks.ts
@@ -19,6 +19,7 @@ export const NetworkToCoinGeckoPlatformId: { [x in Networks]?: string } = {
   [Networks.Linea]: 'linea',
   [Networks.zkSync]: 'zksync',
   [Networks.Core]: 'coredaoorg',
+  [Networks.HyperEVM]: 'hyperliquid',
 
   ...Object.values(CosmosNetworks).reduce(
     (accum, n) => ({
@@ -51,6 +52,7 @@ export const ChainIds: { [x in Networks]?: string } = {
   [Networks.Linea]: '59144',
   [Networks.zkSync]: '324',
   [Networks.Core]: '1116',
+  [Networks.HyperEVM]: '999',
 
   ...Object.values(CosmosNetworks).reduce(
     (accum, n) => ({

--- a/packages/common/src/enums/networks.enum.ts
+++ b/packages/common/src/enums/networks.enum.ts
@@ -31,6 +31,7 @@ export enum EvmNetworks {
   Viction = 'viction',
   Core = 'core',
   Sonic = 'sonic',
+  HyperEVM = 'hyperevm',
 }
 
 export enum CosmosNetworks {


### PR DESCRIPTION
This pull request adds support for the `HyperEVM` network to the codebase. The changes ensure that `HyperEVM` is recognized as a valid network and is properly mapped to its corresponding identifiers and platform IDs.

Network support additions:

* Added `HyperEVM` to the `EvmNetworks` enum in `networks.enum.ts`, allowing it to be referenced throughout the codebase.

Identifier mappings:

* Mapped `HyperEVM` to its CoinGecko platform ID (`hyperliquid`) in `NetworkToCoinGeckoPlatformId` within `networks.ts`.
* Mapped `HyperEVM` to its chain ID (`999`) in `ChainIds` within `networks.ts`.