### PR TITLE
feat: add katana

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakekit/common",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "scripts": {
     "clean": "rm -rf lib",
     "build": "yarn clean && tsc -b ./tsconfig.cjs.json && tsc -b ./tsconfig.esm.json",

--- a/packages/common/src/constants/networks.ts
+++ b/packages/common/src/constants/networks.ts
@@ -20,6 +20,7 @@ export const NetworkToCoinGeckoPlatformId: { [x in Networks]?: string } = {
   [Networks.zkSync]: 'zksync',
   [Networks.Core]: 'coredaoorg',
   [Networks.HyperEVM]: 'hyperliquid',
+  [Networks.Katana]: 'katana',
 
   ...Object.values(CosmosNetworks).reduce(
     (accum, n) => ({
@@ -53,6 +54,7 @@ export const ChainIds: { [x in Networks]?: string } = {
   [Networks.zkSync]: '324',
   [Networks.Core]: '1116',
   [Networks.HyperEVM]: '999',
+  [Networks.Katana]: '747474',
 
   ...Object.values(CosmosNetworks).reduce(
     (accum, n) => ({

--- a/packages/common/src/enums/networks.enum.ts
+++ b/packages/common/src/enums/networks.enum.ts
@@ -17,6 +17,7 @@ export enum EvmNetworks {
   zkSync = 'zksync',
   Linea = 'linea',
   Unichain = 'unichain',
+  Katana = 'katana',
 
   // Other EVM
   AvalancheC = 'avalanche-c',


### PR DESCRIPTION
This pull request updates the `@stakekit/common` package to support the new `Katana` network. The changes ensure that `Katana` is recognized across the codebase, with its identifiers added to relevant network constants and enums.

**Support for Katana network:**

* Added `Katana` to the `EvmNetworks` enum in `networks.enum.ts`, enabling its use as a recognized EVM network.
* Registered `Katana` in the `NetworkToCoinGeckoPlatformId` mapping in `networks.ts`, allowing integration with CoinGecko for price and metadata retrieval.
* Added `Katana` to the `ChainIds` mapping in `networks.ts`, specifying its chain ID as `747474` for correct identification in chain-related logic.

**Version bump:**

* Updated the package version in `package.json` from `0.0.56` to `0.0.57` to reflect the new network support.